### PR TITLE
Fix/subtitle transfer

### DIFF
--- a/app/filetransfer.py
+++ b/app/filetransfer.py
@@ -1069,7 +1069,7 @@ class FileTransfer:
             # 已存在的集
             exists_episodes = []
             for dest_path in dest_paths:
-                if category_flag:
+                if category_flag and meta_info.category:
                     dest_path = os.path.join(dest_path, meta_info.category, dir_name, season_name)
                 else:
                     dest_path = os.path.join(dest_path, dir_name, season_name)

--- a/app/media/meta/metaanime.py
+++ b/app/media/meta/metaanime.py
@@ -168,6 +168,9 @@ class MetaAnime(MetaBase):
         """
         对命名进行预处理
         """
+
+        _anime_sub = r"\.sc|\.tc|\.jp|\.jpsc|\.tcsc|\.sctc|\.jptc|\.zh|\.en|\.chs|\.cht"
+
         if not title:
             return title
         # 所有【】换成[]
@@ -190,6 +193,8 @@ class MetaAnime(MetaBase):
         title = re.sub(r"\[TV\s+(\d{1,4})", r"[\1", title, flags=re.IGNORECASE)
         # 将4K转为2160p
         title = re.sub(r'\[4k]', '2160p', title, flags=re.IGNORECASE)
+        # 处理ch，cn等被识别成name的情况
+        title = re.sub(_anime_sub, '', title, flags=re.IGNORECASE)
         # 处理/分隔的中英文标题
         names = title.split("]")
         if len(names) > 1 and title.find("- ") == -1:

--- a/web/main.py
+++ b/web/main.py
@@ -44,6 +44,7 @@ from web.backend.user import User
 from web.backend.wallpaper import get_login_wallpaper
 from web.backend.web_utils import WebUtils
 from web.security import require_auth
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 # 配置文件锁
 ConfigLock = Lock()
@@ -53,6 +54,7 @@ App = Flask(__name__)
 App.config['JSON_AS_ASCII'] = False
 App.secret_key = os.urandom(24)
 App.permanent_session_lifetime = datetime.timedelta(days=30)
+App.wsgi_app = ProxyFix(App.wsgi_app, x_for=1, x_host=1, x_prefix=1)
 
 # 启用压缩
 Compress(App)


### PR DESCRIPTION
修复字幕转移识别失败的问题

具体case:
```
// [[Nekomoe kissaten][Irozuku Sekai no Ashita kara][03][BDRip][Ma10p_1080p][x265_flac].mkv] 
// name被识别为Irozuku Sekai no Ashita kara
// [[Nekomoe kissaten][Irozuku Sekai no Ashita kara][03][BDRIP][Ma10p_1080p][x265_flac].TC.ass]
// name 被识别为Nekomoe kissaten

这个MR在提取media info前，会将filename中 TC, SC, CHS 等删去，于是可以正确识别name，进而正确转移字幕

```
